### PR TITLE
Correção de timestamps na criação de um período e do redirecionamento após erro em importação

### DIFF
--- a/app/Http/Controllers/TurmaController.php
+++ b/app/Http/Controllers/TurmaController.php
@@ -128,7 +128,7 @@ class TurmaController extends Controller
 
                     $disciplina = Disciplina::where('codigo', $aluno['cod_disciplina'])->first();
 
-                    if(is_null($disciplina)) return back()->withErrors(['disciplina' => 'A disciplina não existe. Entre em contato com o administrador para que seja cadastrada.']);
+                    if(is_null($disciplina)) return redirect()->route('importarTurma')->withErrors(['disciplina' => 'A disciplina não existe. Entre em contato com o administrador para que seja cadastrada.']);
                     else
                     {
                         $turma = Turma::firstOrCreate([

--- a/app/Http/Controllers/TurmaController.php
+++ b/app/Http/Controllers/TurmaController.php
@@ -111,7 +111,7 @@ class TurmaController extends Controller
     {
         Excel::setDelimiter(';'); // Muda o delimitador de campos para ponto-e-vírgula (;)
 
-        Excel::load($request->file('file'), function ($reader) {
+        $callback = Excel::load($request->file('file'), function ($reader) {
 
             $alunos = $reader->get()->toArray();
             $turma = null; // sinaliza se a turma já foi criada ou não
@@ -128,7 +128,7 @@ class TurmaController extends Controller
 
                     $disciplina = Disciplina::where('codigo', $aluno['cod_disciplina'])->first();
 
-                    if(is_null($disciplina)) return redirect()->route('importarTurma')->withErrors(['disciplina' => 'A disciplina não existe. Entre em contato com o administrador para que seja cadastrada.']);
+                    if(is_null($disciplina)) return 1;
                     else
                     {
                         $turma = Turma::firstOrCreate([
@@ -178,9 +178,12 @@ class TurmaController extends Controller
                     'turma_id' => $turma->id
                 ]);
             }
+
+            return 0;
         });
 
-        return redirect()->route('home');
+        if($callback) return back()->withErrors(['disciplina' => 'A disciplina não existe. Entre em contato com o administrador para que seja cadastrada.']);
+        else return redirect()->route('home');
     }
 
     public function getAlunoDetails($campo, $valor, $grupo)

--- a/app/Periodo.php
+++ b/app/Periodo.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class Periodo extends Model
 {
+
+    public $timestamps = false;
+
     protected $hidden = [
         'id',
     ];


### PR DESCRIPTION
Adicionado a omissão das timestamps no modelo Periodo e em caso de erro da falta da disciplina, o usuário é redirecionado para a página de importação.